### PR TITLE
utilities: use a different value for the weak pointer

### DIFF
--- a/utilities.lisp
+++ b/utilities.lisp
@@ -39,7 +39,7 @@ indicating whether an element was found or not."
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (defconstant +can-make-weak-pointer+
     (not (null (trivial-garbage:weak-pointer-p
-                (trivial-garbage:make-weak-pointer t))))))
+                (trivial-garbage:make-weak-pointer "<foo>"))))))
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (unless +can-make-weak-pointer+


### PR DESCRIPTION
Using T is correct, however ECL (including the last release) have issues with
that particular weak value. The problem is fixed in ECL, however before there
is no new release Flexichain is not usable on this implementation. Changing T
to "foo" which is equally good from the semantic perspective fixes the issue.